### PR TITLE
Add a null check to TMPro sprite asset material checking

### DIFF
--- a/Assets/Coffee/UIExtensions/UIEffect/Scripts/Common/BaseMeshEffect.cs
+++ b/Assets/Coffee/UIExtensions/UIEffect/Scripts/Common/BaseMeshEffect.cs
@@ -242,6 +242,11 @@ namespace Coffee.UIExtensions
 
 			// Is the sprite asset for dissolve?
 			TMP_SpriteAsset spriteAsset = textMeshPro.spriteAsset ?? TMP_Settings.GetSpriteAsset ();
+			// Sprite asset might not exist at all
+			if(spriteAsset == null) {
+				return;
+			}
+
 			m = spriteAsset.material;
 			if (m && m.shader != spriteShader && textMeshPro.richText && textMeshPro.text.Contains("<sprite="))
 			{


### PR DESCRIPTION
If the Sprite Asset has not been set in TMPro settings, there is an error which prevents UIEffect from drawing its TMPro warning. This pull request adds a null-check to prevent such error.

Reproducing bug:
- Use UIEffect normally, but make sure that the SpriteAsset field in TMPro Settings is empty
- Selecting the text object with UIEffect causes an error