### PR TITLE
Fix: UIFlip not support pivots other than (0.5, 0.5)

### DIFF
--- a/Scripts/UIFlip.cs
+++ b/Scripts/UIFlip.cs
@@ -53,15 +53,28 @@ namespace Coffee.UIEffects
         {
             if (!isActiveAndEnabled) return;
 
+            var pivot = rectTransform.pivot;
+            var rect = rectTransform.rect;
+            var width = rect.size.x;
+            var height = rect.size.y;
             var vt = default(UIVertex);
             for (var i = 0; i < vh.currentVertCount; i++)
             {
                 vh.PopulateUIVertex(ref vt, i);
                 var pos = vt.position;
-                vt.position = new Vector3(
-                    m_Horizontal ? -pos.x : pos.x,
-                    m_Veritical ? -pos.y : pos.y
-                );
+                if (horizontal)
+                {
+                    // pivot = 0.5, x = -x;
+                    // pivot = 0, x = width - x;
+                    // pivot = 1, x = -width - x;
+                    pos.x = (0.5f - pivot.x) * 2 * width - pos.x;
+                }
+
+                if (vertical)
+                {
+                    pos.y = (0.5f - pivot.y) * 2 * height - pos.y;
+                }
+                vertex.position = pos;
                 vh.SetUIVertex(vt, i);
             }
         }


### PR DESCRIPTION
take pivot into account, so that UIFlip.cs could work correctly when the pivot is anything but (0.5, 0.5)