### PR TITLE
Added example of `using` the Coffee namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Open `
 ![](https://user-images.githubusercontent.com/12690315/38594668-636dd3ac-3d82-11e8-9951-820964a6a95f.gif)
 3. You can add or modify effects from the script.  
 ```cs
+using Coffee.UIEffects;
+
 var uieffect = gameObject.AddComponent<UIEffect>();
 uieffect.effectMode = EffectMode.Grayscale;
 uieffect.effectFactor = 0.85f;


### PR DESCRIPTION
Had to go into the source code to see what the namespace was. Might as well include in the example how to include the namespace with `using`.