### PR TITLE
Fix to Shader Keywords Culture Issue #259

### DIFF
--- a/Scripts/Common/BaseMaterialEffect.cs
+++ b/Scripts/Common/BaseMaterialEffect.cs
@@ -88,7 +88,7 @@ namespace Coffee.UIEffects
         {
             // Set shader keywords as variants
             var keywords = variants.Where(x => 0 < (int) x)
-                .Select(x => x.ToString().ToUpper())
+                .Select(x => x.ToString().ToUpperInvariant())
                 .Concat(newMaterial.shaderKeywords)
                 .Distinct()
                 .ToArray();


### PR DESCRIPTION
Issue: [BaseMaterialEffect fails to set Shader Keywords with some cultures (E.g. Turkish)](https://github.com/mob-sakai/UIEffect/issues/259)