### PR TITLE
feat: add option to not automatically plays tweener effect

### DIFF
--- a/Packages/src/Editor/UIEffectTweenerEditor.cs
+++ b/Packages/src/Editor/UIEffectTweenerEditor.cs
@@ -17,6 +17,7 @@ namespace Coffee.UIEffects.Editors
         private SerializedProperty _restartOnEnable;
         private SerializedProperty _updateMode;
         private SerializedProperty _wrapMode;
+        private SerializedProperty _startMode;
 
         private void OnEnable()
         {
@@ -29,6 +30,7 @@ namespace Coffee.UIEffects.Editors
             _interval = serializedObject.FindProperty("m_Interval");
             _wrapMode = serializedObject.FindProperty("m_WrapMode");
             _updateMode = serializedObject.FindProperty("m_UpdateMode");
+            _startMode = serializedObject.FindProperty("m_StartMode");
         }
 
         public override void OnInspectorGUI()
@@ -44,6 +46,7 @@ namespace Coffee.UIEffects.Editors
             EditorGUILayout.PropertyField(_restartOnEnable);
             EditorGUILayout.PropertyField(_wrapMode);
             EditorGUILayout.PropertyField(_updateMode);
+            EditorGUILayout.PropertyField(_startMode);
             serializedObject.ApplyModifiedProperties();
             DrawPlayer(target as UIEffectTweener);
             Profiler.EndSample();


### PR DESCRIPTION
# Pull Request Template

## Description

Change Summary:
Added a new option on the tweener effect called "StartMode" to set it to not automatically play on start. eg. you have an image with a UIEffect and UIEffectTweener and do not want the effect to play instantly when the object starts but still want to use Normal/Unscaled update mode to not have to tween values manually in code.

Context/Motivation:
I was having an issue where I was using a UIEffect component together with UIEffectTweener and it was tweening my values automatically on start. Since I still wanted to use Normal/Unscaled update mode and did not want to always enable/disable the component I created a new option called **StartMode** where you can set it to **manual** and the script will wait until you first call Play() on UIEffectTweener to start modifying the values, also you can keep it on **automatic** and use the default behavior.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Windows
- Unity version: 2020.3.48f1 / Unity 6000.0.28f1
- Build options: Mono, URP

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings