### PR TITLE
Allow using non-HDR color pickers on gradient options

### DIFF
--- a/Assets/Demos/GradationTest/GradationTest.unity
+++ b/Assets/Demos/GradationTest/GradationTest.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -213,7 +213,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1299999091}
   - {fileID: 591404685}
@@ -253,7 +252,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 320007022}
   m_RootOrder: 1
@@ -380,7 +378,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 1, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 1
@@ -415,7 +412,6 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 320007022}
   m_RootOrder: 0
@@ -507,6 +503,9 @@ MonoBehaviour:
   m_PlayOnEnable: 1
   m_WrapMode: 1
   m_UpdateMode: 0
+  m_OnComplete:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &1299999096
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -525,6 +524,7 @@ MonoBehaviour:
   m_ColorFilter: 0
   m_ColorIntensity: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_ColorGlow: 0
   m_SamplingFilter: 0
   m_SamplingIntensity: 0.5
   m_SamplingScale: 1
@@ -540,6 +540,7 @@ MonoBehaviour:
   m_TransitionSoftness: 0.2
   m_TransitionColorFilter: 6
   m_TransitionColor: {r: 0, g: 0.5, b: 1, a: 1}
+  m_TransitionColorGlow: 0
   m_TargetMode: 0
   m_TargetColor: {r: 1, g: 1, b: 1, a: 1}
   m_TargetRange: 0.1
@@ -553,10 +554,11 @@ MonoBehaviour:
   m_ShadowFade: 0.9
   m_ShadowMirrorScale: 0.5
   m_ShadowBlurIntensity: 1
+  m_ShadowColorFilter: 4
   m_ShadowColor: {r: 1, g: 1, b: 1, a: 1}
-  m_ShadowGlow: 0
+  m_ShadowColorGlow: 0
   m_GradationMode: 2
-  m_GradationColor1: {r: 1, g: 1, b: 1, a: 1}
+  m_GradationColor1: {r: 0.04517317, g: 0, b: 1, a: 1}
   m_GradationColor2: {r: 1, g: 1, b: 1, a: 1}
   m_GradationGradient:
     serializedVersion: 2
@@ -587,9 +589,10 @@ MonoBehaviour:
     m_Mode: 0
     m_NumColorKeys: 8
     m_NumAlphaKeys: 2
-  m_GradationOffset: 1
+  m_GradationOffset: 0
   m_GradationScale: 2
-  m_AllowExtendVertex: 1
+  m_GradationRotation: 0
+  m_AllowToModifyMeshShape: 1
 --- !u!1 &1303535690
 GameObject:
   m_ObjectHideFlags: 0
@@ -620,7 +623,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_SendPointerHoverToParent: 1
   m_HorizontalAxis: Horizontal
   m_VerticalAxis: Vertical
   m_SubmitButton: Submit
@@ -653,7 +655,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -747,7 +748,6 @@ Transform:
   m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 2

--- a/Assets/ProjectSettings/UIEffectProjectSettings.asset
+++ b/Assets/ProjectSettings/UIEffectProjectSettings.asset
@@ -13,54 +13,45 @@ ShaderVariantCollection:
       variants:
       - keywords: 
         passType: 0
-      - keywords: COLOR_ADDITIVE
+      - keywords: TONE_GRAYSCALE
         passType: 0
-      - keywords: COLOR_ADDITIVE SAMPLING_BLUR_FAST
+      - keywords: TONE_SEPIA
         passType: 0
-      - keywords: COLOR_ADDITIVE SAMPLING_BLUR_FAST UNITY_UI_CLIP_RECT
+      - keywords: TONE_NEGATIVE
         passType: 0
-      - keywords: COLOR_CONTRAST
+      - keywords: TONE_RETRO
         passType: 0
-      - keywords: COLOR_HSV_MODIFIER
-        passType: 0
-      - keywords: COLOR_HSV_MODIFIER TARGET_HUE
-        passType: 0
-      - keywords: COLOR_HSV_MODIFIER TARGET_LUMINANCE
+      - keywords: TONE_POSTERIZE
         passType: 0
       - keywords: COLOR_MULTIPLY
         passType: 0
-      - keywords: COLOR_MULTIPLY SAMPLING_BLUR_FAST SHADOW_COLOR_REPLACE TARGET_HUE
-          TONE_GRAYSCALE TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_DISSOLVE
-        passType: 0
-      - keywords: COLOR_MULTIPLY_ADDITIVE
-        passType: 0
-      - keywords: COLOR_MULTIPLY_ADDITIVE SAMPLING_BLUR_FAST TONE_GRAYSCALE TRANSITION_COLOR_MULTIPLY_ADDITIVE
-          TRANSITION_DISSOLVE
-        passType: 0
-      - keywords: COLOR_MULTIPLY_ADDITIVE SAMPLING_RGB_SHIFT TONE_GRAYSCALE TRANSITION_COLOR_MULTIPLY_ADDITIVE
-          TRANSITION_DISSOLVE
-        passType: 0
-      - keywords: COLOR_MULTIPLY_LUMINANCE
-        passType: 0
-      - keywords: COLOR_REPLACE
-        passType: 0
-      - keywords: COLOR_REPLACE SAMPLING_BLUR_FAST
+      - keywords: COLOR_ADDITIVE
         passType: 0
       - keywords: COLOR_SUBTRACTIVE
         passType: 0
-      - keywords: SAMPLING_BLUR_DETAIL
+      - keywords: COLOR_REPLACE
+        passType: 0
+      - keywords: COLOR_MULTIPLY_LUMINANCE
+        passType: 0
+      - keywords: COLOR_MULTIPLY_ADDITIVE
+        passType: 0
+      - keywords: COLOR_HSV_MODIFIER
+        passType: 0
+      - keywords: COLOR_CONTRAST
         passType: 0
       - keywords: SAMPLING_BLUR_FAST
         passType: 0
       - keywords: SAMPLING_BLUR_FAST TONE_GRAYSCALE
         passType: 0
+      - keywords: COLOR_ADDITIVE SAMPLING_BLUR_FAST
+        passType: 0
+      - keywords: COLOR_ADDITIVE SAMPLING_BLUR_FAST UNITY_UI_CLIP_RECT
+        passType: 0
+      - keywords: COLOR_REPLACE SAMPLING_BLUR_FAST
+        passType: 0
       - keywords: SAMPLING_BLUR_MEDIUM
         passType: 0
-      - keywords: SAMPLING_EDGE_ALPHA
-        passType: 0
-      - keywords: SAMPLING_EDGE_LUMINANCE
-        passType: 0
-      - keywords: SAMPLING_EDGE_LUMINANCE TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MASK
+      - keywords: SAMPLING_BLUR_DETAIL
         passType: 0
       - keywords: SAMPLING_PIXELATION
         passType: 0
@@ -70,39 +61,48 @@ ShaderVariantCollection:
         passType: 0
       - keywords: SAMPLING_RGB_SHIFT
         passType: 0
-      - keywords: TONE_GRAYSCALE
+      - keywords: SAMPLING_EDGE_LUMINANCE
         passType: 0
-      - keywords: TONE_NEGATIVE
+      - keywords: SAMPLING_EDGE_ALPHA
         passType: 0
-      - keywords: TONE_POSTERIZE
+      - keywords: TRANSITION_FADE
         passType: 0
-      - keywords: TONE_RETRO
+      - keywords: TRANSITION_CUTOFF
         passType: 0
-      - keywords: TONE_SEPIA
-        passType: 0
-      - keywords: TRANSITION_BURN TRANSITION_COLOR_MULTIPLY_ADDITIVE
-        passType: 0
-      - keywords: TRANSITION_BURN TRANSITION_COLOR_MULTIPLY_ADDITIVE UNITY_UI_CLIP_RECT
+      - keywords: TRANSITION_COLOR_REPLACE TRANSITION_MELT
         passType: 0
       - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_DISSOLVE
         passType: 0
       - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_DISSOLVE UNITY_UI_CLIP_RECT
         passType: 0
-      - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MASK
+      - keywords: COLOR_MULTIPLY_ADDITIVE SAMPLING_BLUR_FAST TONE_GRAYSCALE TRANSITION_COLOR_MULTIPLY_ADDITIVE
+          TRANSITION_DISSOLVE
         passType: 0
-      - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MELT
-        passType: 0
-      - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MELT UNITY_UI_CLIP_RECT
+      - keywords: COLOR_MULTIPLY_ADDITIVE SAMPLING_RGB_SHIFT TONE_GRAYSCALE TRANSITION_COLOR_MULTIPLY_ADDITIVE
+          TRANSITION_DISSOLVE
         passType: 0
       - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_SHINY
         passType: 0
       - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_SHINY UNITY_UI_CLIP_RECT
         passType: 0
-      - keywords: TRANSITION_COLOR_REPLACE TRANSITION_MELT
+      - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MASK
         passType: 0
-      - keywords: TRANSITION_CUTOFF
+      - keywords: SAMPLING_EDGE_LUMINANCE TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MASK
         passType: 0
-      - keywords: TRANSITION_FADE
+      - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MELT
+        passType: 0
+      - keywords: TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_MELT UNITY_UI_CLIP_RECT
+        passType: 0
+      - keywords: TRANSITION_BURN TRANSITION_COLOR_MULTIPLY_ADDITIVE
+        passType: 0
+      - keywords: TRANSITION_BURN TRANSITION_COLOR_MULTIPLY_ADDITIVE UNITY_UI_CLIP_RECT
+        passType: 0
+      - keywords: COLOR_HSV_MODIFIER TARGET_HUE
+        passType: 0
+      - keywords: COLOR_MULTIPLY SAMPLING_BLUR_FAST SHADOW_COLOR_REPLACE TARGET_HUE
+          TONE_GRAYSCALE TRANSITION_COLOR_MULTIPLY_ADDITIVE TRANSITION_DISSOLVE
+        passType: 0
+      - keywords: COLOR_HSV_MODIFIER TARGET_LUMINANCE
         passType: 0
   - first: {fileID: 4800000, guid: e65241fa80a374114b3f55ed746c04d9, type: 3}
     second:

--- a/Packages/src/Editor/UIEffectEditor.cs
+++ b/Packages/src/Editor/UIEffectEditor.cs
@@ -260,7 +260,7 @@ namespace Coffee.UIEffects.Editors
                 }
 
                 EditorGUILayout.PropertyField(_shadowColorFilter);
-                EditorGUILayout.PropertyField(_shadowColor);
+                DrawColorPickerField(_shadowColor, false);
                 EditorGUILayout.PropertyField(_shadowColorGlow);
                 EditorGUILayout.PropertyField(_shadowFade);
 
@@ -289,12 +289,14 @@ namespace Coffee.UIEffects.Editors
                         EditorGUILayout.PropertyField(_gradationGradient);
                         break;
                     default:
-                        EditorGUILayout.PropertyField(_gradationColor1);
                         var r = EditorGUILayout.GetControlRect();
-                        r.width -= 20;
-                        EditorGUI.PropertyField(r, _gradationColor2);
+                        r.height = EditorGUIUtility.singleLineHeight;
+                        DrawColorPickerField(_gradationColor1, r, new GUIContent("Gradation Color 1"));
+                        r = EditorGUILayout.GetControlRect();
+                        r.width -= 24;
+                        DrawColorPickerField(_gradationColor2, r, new GUIContent("Gradation Color 2"));
 
-                        r.x += r.width;
+                        r.x += r.width + 4;
                         r.width = 20;
                         // Swap colors
                         if (GUI.Button(r, EditorGUIUtility.IconContent("preaudioloopoff"), "iconbutton"))
@@ -324,6 +326,22 @@ namespace Coffee.UIEffects.Editors
             {
                 EditorGUILayout.PropertyField(_allowToModifyMeshShape);
             }
+        }
+
+        private static void DrawColorPickerField(SerializedProperty color, bool showAlpha = true)
+        {
+            var r = EditorGUILayout.GetControlRect();
+            r.height = EditorGUIUtility.singleLineHeight;
+            DrawColorPickerField(color, r, new GUIContent(color.displayName, color.tooltip), showAlpha);
+        }
+
+        private static void DrawColorPickerField(SerializedProperty color, Rect rect, GUIContent label, bool showAlpha = true)
+        {
+            EditorGUI.BeginChangeCheck();
+            EditorGUI.showMixedValue = color.hasMultipleDifferentValues;
+            var colorField = EditorGUI.ColorField(rect, label, color.colorValue, true, showAlpha, UIEffectProjectSettings.useHdrColorPicker);
+            if (EditorGUI.EndChangeCheck())
+                color.colorValue = colorField;
         }
 
         private static void DrawColor(SerializedProperty filter, SerializedProperty color, ColorFilter prevFilter)
@@ -361,7 +379,7 @@ namespace Coffee.UIEffects.Editors
                     color.colorValue = Color.white;
                 }
 
-                EditorGUILayout.PropertyField(color);
+                DrawColorPickerField(color);
             }
         }
 

--- a/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
+++ b/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 using Coffee.UIEffectInternal;
 using UnityEditorInternal;
 
+#if UNITY_2021_3_OR_NEWER
+using UnityEditor.Build;
+#endif
+
 namespace Coffee.UIEffects.Editors
 {
     [CustomEditor(typeof(UIEffectProjectSettings))]
@@ -65,8 +69,8 @@ namespace Coffee.UIEffects.Editors
         {
             // Called when the domain reloads,
             // So we check if the scripting define is altered manually
-#if UNITY_2023_1_OR_NEWER
-            PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#if UNITY_2021_3_OR_NEWER
+            PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup), out var defines);
 #else
             PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
 #endif
@@ -87,8 +91,8 @@ namespace Coffee.UIEffects.Editors
                 _noHdrGradient = !_noHdrGradient;
                 if (_noHdrGradient)
                 {
-#if UNITY_2023_1_OR_NEWER
-                    PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#if UNITY_2021_3_OR_NEWER
+                    PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup), out var defines);
 #else
                     PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
 #endif
@@ -96,16 +100,16 @@ namespace Coffee.UIEffects.Editors
                     Array.Resize(ref defines, defines.Length + 1);
                     defines[defines.Length - 1] = k_NoHDRGradientScriptingDefine;
 
-#if UNITY_2023_1_OR_NEWER
-                    PlayerSettings.SetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#if UNITY_2021_3_OR_NEWER
+                    PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup), defines);
 #else
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
 #endif
                 }
                 else
                 {
-#if UNITY_2023_1_OR_NEWER
-                    PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#if UNITY_2021_3_OR_NEWER
+                    PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup), out var defines);
 #else
                     PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
 #endif
@@ -113,8 +117,8 @@ namespace Coffee.UIEffects.Editors
                     defines[Array.IndexOf(defines, k_NoHDRGradientScriptingDefine)] = defines[defines.Length - 1];
                     Array.Resize(ref defines, defines.Length - 1);
 
-#if UNITY_2023_1_OR_NEWER
-                    PlayerSettings.SetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#if UNITY_2021_3_OR_NEWER
+                    PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.FromBuildTargetGroup(EditorUserBuildSettings.selectedBuildTargetGroup), defines);
 #else
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
 #endif

--- a/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
+++ b/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
@@ -9,10 +9,10 @@ namespace Coffee.UIEffects.Editors
     [CustomEditor(typeof(UIEffectProjectSettings))]
     public class UIEffectProjectSettingsEditor : Editor
     {
-        private const string k_HDRGradientScriptingDefine = "UIEFFECTS_GRADIENT_HDR";
+        private const string k_NoHDRGradientScriptingDefine = "UIEFFECTS_GRADIENT_NO_HDR";
 
         private ReorderableList _reorderableList;
-        private bool _useHdrGradient;
+        private bool _noHdrGradient;
         private SerializedProperty _transformSensitivity;
         private bool _isInitialized;
         private ShaderVariantRegistryEditor _shaderVariantRegistryEditor;
@@ -70,7 +70,7 @@ namespace Coffee.UIEffects.Editors
 #else
             PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
 #endif
-            _useHdrGradient = Array.IndexOf(defines, k_HDRGradientScriptingDefine) != -1;
+            _noHdrGradient = Array.IndexOf(defines, k_NoHDRGradientScriptingDefine) != -1;
         }
 
         public override void OnInspectorGUI()
@@ -80,10 +80,12 @@ namespace Coffee.UIEffects.Editors
 
             // Settings
             EditorGUILayout.PropertyField(_transformSensitivity);
-            if (EditorGUILayout.Toggle(new GUIContent("HDR Gradient", "Use HDR colors on two-color gradients"), _useHdrGradient) != _useHdrGradient)
+
+            var useHdrGradient = !_noHdrGradient;
+            if (EditorGUILayout.Toggle(new GUIContent("HDR Gradient", "Use HDR colors on two-color gradients"), useHdrGradient) != useHdrGradient)
             {
-                _useHdrGradient = !_useHdrGradient;
-                if (_useHdrGradient)
+                _noHdrGradient = !_noHdrGradient;
+                if (_noHdrGradient)
                 {
 #if UNITY_2023_1_OR_NEWER
                     PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
@@ -92,7 +94,7 @@ namespace Coffee.UIEffects.Editors
 #endif
 
                     Array.Resize(ref defines, defines.Length + 1);
-                    defines[defines.Length - 1] = k_HDRGradientScriptingDefine;
+                    defines[defines.Length - 1] = k_NoHDRGradientScriptingDefine;
 
 #if UNITY_2023_1_OR_NEWER
                     PlayerSettings.SetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
@@ -108,7 +110,7 @@ namespace Coffee.UIEffects.Editors
                     PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
 #endif
 
-                    defines[Array.IndexOf(defines, k_HDRGradientScriptingDefine)] = defines[defines.Length - 1];
+                    defines[Array.IndexOf(defines, k_NoHDRGradientScriptingDefine)] = defines[defines.Length - 1];
                     Array.Resize(ref defines, defines.Length - 1);
 
 #if UNITY_2023_1_OR_NEWER

--- a/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
+++ b/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
@@ -65,7 +65,11 @@ namespace Coffee.UIEffects.Editors
         {
             // Called when the domain reloads,
             // So we check if the scripting define is altered manually
+#if UNITY_2023_1_OR_NEWER
+            PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#else
             PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#endif
             _useHdrGradient = Array.IndexOf(defines, k_HDRGradientScriptingDefine) != -1;
         }
 
@@ -81,17 +85,37 @@ namespace Coffee.UIEffects.Editors
                 _useHdrGradient = !_useHdrGradient;
                 if (_useHdrGradient)
                 {
+#if UNITY_2023_1_OR_NEWER
+                    PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#else
                     PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#endif
+
                     Array.Resize(ref defines, defines.Length + 1);
                     defines[defines.Length - 1] = k_HDRGradientScriptingDefine;
+
+#if UNITY_2023_1_OR_NEWER
+                    PlayerSettings.SetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#else
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#endif
                 }
                 else
                 {
+#if UNITY_2023_1_OR_NEWER
+                    PlayerSettings.GetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#else
                     PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, out var defines);
+#endif
+
                     defines[Array.IndexOf(defines, k_HDRGradientScriptingDefine)] = defines[defines.Length - 1];
                     Array.Resize(ref defines, defines.Length - 1);
+
+#if UNITY_2023_1_OR_NEWER
+                    PlayerSettings.SetScriptingDefineSymbols(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#else
                     PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, defines);
+#endif
                 }
             }
             _reorderableList.DoLayoutList();

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -362,7 +362,7 @@ UIEffectProjectSettings.shaderVariantCollection.WarmUp();
 
 ### Project Settings
 
-![](https://github.com/user-attachments/assets/54dd42cf-099d-4fb1-b699-cad29bf211b6)
+![](https://github.com/user-attachments/assets/e9938d45-ccb1-4e8a-819d-01329cda637a)
 
 You can adjust the project-wide settings for UIEffect. (`Edit > Project Settings > UI > UIEffect`)
 

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -368,6 +368,7 @@ You can adjust the project-wide settings for UIEffect. (`Edit > Project Settings
 
 - **Transform Sensitivity**: `Low`, `Medium`, `High`
   - Set the sensitivity of the transformation when `Use Target Transform` is enabled in `UIEffectReplica` component.
+- **HDR Gradient**: Use HDR input fields for two-color gradients.
 - **Runtime Presets**: A list of presets that can be loaded at runtime. Load them using `UIEffect.LoadPreset(presetName)` method.
 - **Optional Shaders (UIEffect)**: A list of shaders that will be prioritized when a ui-effect shader is
   requested.

--- a/Packages/src/Runtime/UIEffect.cs
+++ b/Packages/src/Runtime/UIEffect.cs
@@ -514,8 +514,8 @@ namespace Coffee.UIEffects
             {
                 if (m_BlendType == value) return;
                 (m_SrcBlendMode, m_DstBlendMode) = (m_BlendType, m_SrcBlendMode, m_DstBlendMode).Convert();
-                context.srcBlendMode             = m_SrcBlendMode;
-                context.dstBlendMode             = m_DstBlendMode;
+                context.srcBlendMode = m_SrcBlendMode;
+                context.dstBlendMode = m_DstBlendMode;
                 ApplyContextToMaterial();
             }
         }
@@ -531,7 +531,7 @@ namespace Coffee.UIEffects
             {
                 if (m_SrcBlendMode == value) return;
                 context.srcBlendMode = m_SrcBlendMode = value;
-                m_BlendType          = (m_SrcBlendMode, m_DstBlendMode).Convert();
+                m_BlendType = (m_SrcBlendMode, m_DstBlendMode).Convert();
                 ApplyContextToMaterial();
             }
         }
@@ -547,7 +547,7 @@ namespace Coffee.UIEffects
             {
                 if (m_DstBlendMode == value) return;
                 context.dstBlendMode = m_DstBlendMode = value;
-                m_BlendType          = (m_SrcBlendMode, m_DstBlendMode).Convert();
+                m_BlendType = (m_SrcBlendMode, m_DstBlendMode).Convert();
                 ApplyContextToMaterial();
             }
         }
@@ -733,7 +733,7 @@ namespace Coffee.UIEffects
             }
         }
 
-        public  List<UIEffectReplica> replicas => _replicas ??= InternalListPool<UIEffectReplica>.Rent();
+        public List<UIEffectReplica> replicas => _replicas ??= InternalListPool<UIEffectReplica>.Rent();
         private List<UIEffectReplica> _replicas;
 
         protected override void OnEnable()
@@ -795,56 +795,56 @@ namespace Coffee.UIEffects
 
         protected override void UpdateContext(UIEffectContext c)
         {
-            c.toneFilter    = m_ToneFilter;
+            c.toneFilter = m_ToneFilter;
             c.toneIntensity = m_ToneIntensity;
-            c.toneParams    = m_ToneParams;
+            c.toneParams = m_ToneParams;
 
-            c.colorFilter    = m_ColorFilter;
-            c.color          = m_Color;
+            c.colorFilter = m_ColorFilter;
+            c.color = m_Color;
             c.colorIntensity = m_ColorIntensity;
-            c.colorGlow      = m_ColorGlow;
+            c.colorGlow = m_ColorGlow;
 
-            c.samplingFilter    = m_SamplingFilter;
+            c.samplingFilter = m_SamplingFilter;
             c.samplingIntensity = m_SamplingIntensity;
 
-            c.transitionFilter          = m_TransitionFilter;
-            c.transitionRate            = m_TransitionRate;
-            c.transitionReverse         = m_TransitionReverse;
-            c.transitionTex             = m_TransitionTex;
-            c.transitionTexScale        = m_TransitionTexScale;
-            c.transitionTexOffset       = m_TransitionTexOffset;
-            c.transitionRotation        = m_TransitionRotation;
+            c.transitionFilter = m_TransitionFilter;
+            c.transitionRate = m_TransitionRate;
+            c.transitionReverse = m_TransitionReverse;
+            c.transitionTex = m_TransitionTex;
+            c.transitionTexScale = m_TransitionTexScale;
+            c.transitionTexOffset = m_TransitionTexOffset;
+            c.transitionRotation = m_TransitionRotation;
             c.transitionKeepAspectRatio = m_TransitionKeepAspectRatio;
-            c.transitionWidth           = m_TransitionWidth;
-            c.transitionSoftness        = m_TransitionSoftness;
-            c.transitionColorFilter     = m_TransitionColorFilter;
-            c.transitionColor           = m_TransitionColor;
-            c.transitionColorGlow       = m_TransitionColorGlow;
+            c.transitionWidth = m_TransitionWidth;
+            c.transitionSoftness = m_TransitionSoftness;
+            c.transitionColorFilter = m_TransitionColorFilter;
+            c.transitionColor = m_TransitionColor;
+            c.transitionColorGlow = m_TransitionColorGlow;
 
-            c.targetMode     = m_TargetMode;
-            c.targetColor    = m_TargetColor;
-            c.targetRange    = m_TargetRange;
+            c.targetMode = m_TargetMode;
+            c.targetColor = m_TargetColor;
+            c.targetRange = m_TargetRange;
             c.targetSoftness = m_TargetSoftness;
 
             c.srcBlendMode = m_SrcBlendMode;
             c.dstBlendMode = m_DstBlendMode;
 
-            c.shadowMode          = m_ShadowMode;
-            c.shadowDistance      = m_ShadowDistance;
-            c.shadowIteration     = m_ShadowIteration;
-            c.shadowFade          = m_ShadowFade;
-            c.shadowMirrorScale   = m_ShadowMirrorScale;
+            c.shadowMode = m_ShadowMode;
+            c.shadowDistance = m_ShadowDistance;
+            c.shadowIteration = m_ShadowIteration;
+            c.shadowFade = m_ShadowFade;
+            c.shadowMirrorScale = m_ShadowMirrorScale;
             c.shadowBlurIntensity = m_ShadowBlurIntensity;
-            c.shadowColorFilter   = m_ShadowColorFilter;
-            c.shadowColor         = m_ShadowColor;
-            c.shadowColorGlow     = m_ShadowColorGlow;
+            c.shadowColorFilter = m_ShadowColorFilter;
+            c.shadowColor = m_ShadowColor;
+            c.shadowColorGlow = m_ShadowColorGlow;
 
-            c.gradationMode     = m_GradationMode;
-            c.gradationColor1   = m_GradationColor1;
-            c.gradationColor2   = m_GradationColor2;
+            c.gradationMode = m_GradationMode;
+            c.gradationColor1 = m_GradationColor1;
+            c.gradationColor2 = m_GradationColor2;
             c.gradationGradient = m_GradationGradient;
-            c.gradationOffset   = m_GradationOffset;
-            c.gradationScale    = m_GradationScale;
+            c.gradationOffset = m_GradationOffset;
+            c.gradationScale = m_GradationScale;
             c.gradationRotation = m_GradationRotation;
 
             c.allowToModifyMeshShape = m_AllowToModifyMeshShape;
@@ -922,50 +922,50 @@ namespace Coffee.UIEffects
         {
             if (!preset) return;
 
-            m_ToneFilter    = preset.m_ToneFilter;
+            m_ToneFilter = preset.m_ToneFilter;
             m_ToneIntensity = preset.m_ToneIntensity;
-            m_ToneParams    = preset.m_ToneParams;
+            m_ToneParams = preset.m_ToneParams;
 
-            m_ColorFilter    = preset.m_ColorFilter;
-            m_Color          = preset.m_Color;
+            m_ColorFilter = preset.m_ColorFilter;
+            m_Color = preset.m_Color;
             m_ColorIntensity = preset.m_ColorIntensity;
-            m_ColorGlow      = preset.m_ColorGlow;
+            m_ColorGlow = preset.m_ColorGlow;
 
-            m_SamplingFilter    = preset.m_SamplingFilter;
+            m_SamplingFilter = preset.m_SamplingFilter;
             m_SamplingIntensity = preset.m_SamplingIntensity;
-            m_SamplingScale     = preset.m_SamplingScale;
+            m_SamplingScale = preset.m_SamplingScale;
 
-            m_TransitionFilter          = preset.m_TransitionFilter;
-            m_TransitionRate            = preset.m_TransitionRate;
-            m_TransitionReverse         = preset.m_TransitionReverse;
-            m_TransitionTex             = preset.m_TransitionTex;
-            m_TransitionTexScale        = preset.m_TransitionTexScale;
-            m_TransitionTexOffset       = preset.m_TransitionTexOffset;
-            m_TransitionRotation        = preset.m_TransitionRotation;
+            m_TransitionFilter = preset.m_TransitionFilter;
+            m_TransitionRate = preset.m_TransitionRate;
+            m_TransitionReverse = preset.m_TransitionReverse;
+            m_TransitionTex = preset.m_TransitionTex;
+            m_TransitionTexScale = preset.m_TransitionTexScale;
+            m_TransitionTexOffset = preset.m_TransitionTexOffset;
+            m_TransitionRotation = preset.m_TransitionRotation;
             m_TransitionKeepAspectRatio = preset.m_TransitionKeepAspectRatio;
-            m_TransitionWidth           = preset.m_TransitionWidth;
-            m_TransitionSoftness        = preset.m_TransitionSoftness;
-            m_TransitionColorFilter     = preset.m_TransitionColorFilter;
-            m_TransitionColor           = preset.m_TransitionColor;
-            m_TransitionColorGlow       = preset.m_TransitionColorGlow;
+            m_TransitionWidth = preset.m_TransitionWidth;
+            m_TransitionSoftness = preset.m_TransitionSoftness;
+            m_TransitionColorFilter = preset.m_TransitionColorFilter;
+            m_TransitionColor = preset.m_TransitionColor;
+            m_TransitionColorGlow = preset.m_TransitionColorGlow;
 
-            m_TargetMode     = preset.m_TargetMode;
-            m_TargetColor    = preset.m_TargetColor;
-            m_TargetRange    = preset.m_TargetRange;
+            m_TargetMode = preset.m_TargetMode;
+            m_TargetColor = preset.m_TargetColor;
+            m_TargetRange = preset.m_TargetRange;
             m_TargetSoftness = preset.m_TargetSoftness;
 
-            m_BlendType                      = preset.m_BlendType;
+            m_BlendType = preset.m_BlendType;
             (m_SrcBlendMode, m_DstBlendMode) = (m_BlendType, preset.m_SrcBlendMode, preset.m_DstBlendMode).Convert();
 
-            m_ShadowMode          = preset.m_ShadowMode;
-            m_ShadowDistance      = preset.m_ShadowDistance;
-            m_ShadowIteration     = preset.m_ShadowIteration;
-            m_ShadowFade          = preset.m_ShadowFade;
-            m_ShadowMirrorScale   = preset.m_ShadowMirrorScale;
+            m_ShadowMode = preset.m_ShadowMode;
+            m_ShadowDistance = preset.m_ShadowDistance;
+            m_ShadowIteration = preset.m_ShadowIteration;
+            m_ShadowFade = preset.m_ShadowFade;
+            m_ShadowMirrorScale = preset.m_ShadowMirrorScale;
             m_ShadowBlurIntensity = preset.m_ShadowBlurIntensity;
-            m_ShadowColorFilter   = preset.m_ShadowColorFilter;
-            m_ShadowColor         = preset.m_ShadowColor;
-            m_ShadowColorGlow     = preset.m_ShadowColorGlow;
+            m_ShadowColorFilter = preset.m_ShadowColorFilter;
+            m_ShadowColor = preset.m_ShadowColor;
+            m_ShadowColorGlow = preset.m_ShadowColorGlow;
 
             UpdateContext(context);
             ApplyContextToMaterial();
@@ -975,57 +975,57 @@ namespace Coffee.UIEffects
 
         internal void CopyFrom(UIEffectContext c)
         {
-            m_ToneFilter    = c.toneFilter;
+            m_ToneFilter = c.toneFilter;
             m_ToneIntensity = c.toneIntensity;
-            m_ToneParams    = c.toneParams;
+            m_ToneParams = c.toneParams;
 
-            m_ColorFilter    = c.colorFilter;
-            m_Color          = c.color;
+            m_ColorFilter = c.colorFilter;
+            m_Color = c.color;
             m_ColorIntensity = c.colorIntensity;
-            m_ColorGlow      = c.colorGlow;
+            m_ColorGlow = c.colorGlow;
 
-            m_SamplingFilter    = c.samplingFilter;
+            m_SamplingFilter = c.samplingFilter;
             m_SamplingIntensity = c.samplingIntensity;
 
-            m_TransitionFilter          = c.transitionFilter;
-            m_TransitionRate            = c.transitionRate;
-            m_TransitionReverse         = c.transitionReverse;
-            m_TransitionTex             = c.transitionTex;
-            m_TransitionTexScale        = c.transitionTexScale;
-            m_TransitionTexOffset       = c.transitionTexOffset;
-            m_TransitionRotation        = c.transitionRotation;
+            m_TransitionFilter = c.transitionFilter;
+            m_TransitionRate = c.transitionRate;
+            m_TransitionReverse = c.transitionReverse;
+            m_TransitionTex = c.transitionTex;
+            m_TransitionTexScale = c.transitionTexScale;
+            m_TransitionTexOffset = c.transitionTexOffset;
+            m_TransitionRotation = c.transitionRotation;
             m_TransitionKeepAspectRatio = c.transitionKeepAspectRatio;
-            m_TransitionWidth           = c.transitionWidth;
-            m_TransitionSoftness        = c.transitionSoftness;
-            m_TransitionColorFilter     = c.transitionColorFilter;
-            m_TransitionColor           = c.transitionColor;
-            m_TransitionColorGlow       = c.transitionColorGlow;
+            m_TransitionWidth = c.transitionWidth;
+            m_TransitionSoftness = c.transitionSoftness;
+            m_TransitionColorFilter = c.transitionColorFilter;
+            m_TransitionColor = c.transitionColor;
+            m_TransitionColorGlow = c.transitionColorGlow;
 
-            m_TargetMode     = c.targetMode;
-            m_TargetColor    = c.targetColor;
-            m_TargetRange    = c.targetRange;
+            m_TargetMode = c.targetMode;
+            m_TargetColor = c.targetColor;
+            m_TargetRange = c.targetRange;
             m_TargetSoftness = c.targetSoftness;
 
             m_SrcBlendMode = c.srcBlendMode;
             m_DstBlendMode = c.dstBlendMode;
-            m_BlendType    = (m_SrcBlendMode, m_DstBlendMode).Convert();
+            m_BlendType = (m_SrcBlendMode, m_DstBlendMode).Convert();
 
-            m_ShadowMode          = c.shadowMode;
-            m_ShadowDistance      = c.shadowDistance;
-            m_ShadowIteration     = c.shadowIteration;
-            m_ShadowFade          = c.shadowFade;
-            m_ShadowMirrorScale   = c.shadowMirrorScale;
+            m_ShadowMode = c.shadowMode;
+            m_ShadowDistance = c.shadowDistance;
+            m_ShadowIteration = c.shadowIteration;
+            m_ShadowFade = c.shadowFade;
+            m_ShadowMirrorScale = c.shadowMirrorScale;
             m_ShadowBlurIntensity = c.shadowBlurIntensity;
-            m_ShadowColorFilter   = c.shadowColorFilter;
-            m_ShadowColor         = c.shadowColor;
-            m_ShadowColorGlow     = c.shadowColorGlow;
+            m_ShadowColorFilter = c.shadowColorFilter;
+            m_ShadowColor = c.shadowColor;
+            m_ShadowColorGlow = c.shadowColorGlow;
 
-            m_GradationMode     = c.gradationMode;
-            m_GradationColor1   = c.gradationColor1;
-            m_GradationColor2   = c.gradationColor2;
+            m_GradationMode = c.gradationMode;
+            m_GradationColor1 = c.gradationColor1;
+            m_GradationColor2 = c.gradationColor2;
             m_GradationGradient = c.gradationGradient;
-            m_GradationOffset   = c.gradationOffset;
-            m_GradationScale    = c.gradationScale;
+            m_GradationOffset = c.gradationOffset;
+            m_GradationScale = c.gradationScale;
             m_GradationRotation = c.gradationRotation;
 
             m_AllowToModifyMeshShape = c.allowToModifyMeshShape;

--- a/Packages/src/Runtime/UIEffect.cs
+++ b/Packages/src/Runtime/UIEffect.cs
@@ -148,11 +148,19 @@ namespace Coffee.UIEffects
         protected GradationMode m_GradationMode = GradationMode.None;
 
         [SerializeField]
+#if UIEFFECTS_GRADIENT_HDR
         [ColorUsage(true, true)]
+#else
+        [ColorUsage(true)]
+#endif
         protected Color m_GradationColor1 = Color.white;
 
         [SerializeField]
+#if UIEFFECTS_GRADIENT_HDR
         [ColorUsage(true, true)]
+#else
+        [ColorUsage(true)]
+#endif
         protected Color m_GradationColor2 = Color.white;
 
         [SerializeField]
@@ -506,8 +514,8 @@ namespace Coffee.UIEffects
             {
                 if (m_BlendType == value) return;
                 (m_SrcBlendMode, m_DstBlendMode) = (m_BlendType, m_SrcBlendMode, m_DstBlendMode).Convert();
-                context.srcBlendMode = m_SrcBlendMode;
-                context.dstBlendMode = m_DstBlendMode;
+                context.srcBlendMode             = m_SrcBlendMode;
+                context.dstBlendMode             = m_DstBlendMode;
                 ApplyContextToMaterial();
             }
         }
@@ -523,7 +531,7 @@ namespace Coffee.UIEffects
             {
                 if (m_SrcBlendMode == value) return;
                 context.srcBlendMode = m_SrcBlendMode = value;
-                m_BlendType = (m_SrcBlendMode, m_DstBlendMode).Convert();
+                m_BlendType          = (m_SrcBlendMode, m_DstBlendMode).Convert();
                 ApplyContextToMaterial();
             }
         }
@@ -539,7 +547,7 @@ namespace Coffee.UIEffects
             {
                 if (m_DstBlendMode == value) return;
                 context.dstBlendMode = m_DstBlendMode = value;
-                m_BlendType = (m_SrcBlendMode, m_DstBlendMode).Convert();
+                m_BlendType          = (m_SrcBlendMode, m_DstBlendMode).Convert();
                 ApplyContextToMaterial();
             }
         }
@@ -725,7 +733,7 @@ namespace Coffee.UIEffects
             }
         }
 
-        public List<UIEffectReplica> replicas => _replicas ??= InternalListPool<UIEffectReplica>.Rent();
+        public  List<UIEffectReplica> replicas => _replicas ??= InternalListPool<UIEffectReplica>.Rent();
         private List<UIEffectReplica> _replicas;
 
         protected override void OnEnable()
@@ -787,56 +795,56 @@ namespace Coffee.UIEffects
 
         protected override void UpdateContext(UIEffectContext c)
         {
-            c.toneFilter = m_ToneFilter;
+            c.toneFilter    = m_ToneFilter;
             c.toneIntensity = m_ToneIntensity;
-            c.toneParams = m_ToneParams;
+            c.toneParams    = m_ToneParams;
 
-            c.colorFilter = m_ColorFilter;
-            c.color = m_Color;
+            c.colorFilter    = m_ColorFilter;
+            c.color          = m_Color;
             c.colorIntensity = m_ColorIntensity;
-            c.colorGlow = m_ColorGlow;
+            c.colorGlow      = m_ColorGlow;
 
-            c.samplingFilter = m_SamplingFilter;
+            c.samplingFilter    = m_SamplingFilter;
             c.samplingIntensity = m_SamplingIntensity;
 
-            c.transitionFilter = m_TransitionFilter;
-            c.transitionRate = m_TransitionRate;
-            c.transitionReverse = m_TransitionReverse;
-            c.transitionTex = m_TransitionTex;
-            c.transitionTexScale = m_TransitionTexScale;
-            c.transitionTexOffset = m_TransitionTexOffset;
-            c.transitionRotation = m_TransitionRotation;
+            c.transitionFilter          = m_TransitionFilter;
+            c.transitionRate            = m_TransitionRate;
+            c.transitionReverse         = m_TransitionReverse;
+            c.transitionTex             = m_TransitionTex;
+            c.transitionTexScale        = m_TransitionTexScale;
+            c.transitionTexOffset       = m_TransitionTexOffset;
+            c.transitionRotation        = m_TransitionRotation;
             c.transitionKeepAspectRatio = m_TransitionKeepAspectRatio;
-            c.transitionWidth = m_TransitionWidth;
-            c.transitionSoftness = m_TransitionSoftness;
-            c.transitionColorFilter = m_TransitionColorFilter;
-            c.transitionColor = m_TransitionColor;
-            c.transitionColorGlow = m_TransitionColorGlow;
+            c.transitionWidth           = m_TransitionWidth;
+            c.transitionSoftness        = m_TransitionSoftness;
+            c.transitionColorFilter     = m_TransitionColorFilter;
+            c.transitionColor           = m_TransitionColor;
+            c.transitionColorGlow       = m_TransitionColorGlow;
 
-            c.targetMode = m_TargetMode;
-            c.targetColor = m_TargetColor;
-            c.targetRange = m_TargetRange;
+            c.targetMode     = m_TargetMode;
+            c.targetColor    = m_TargetColor;
+            c.targetRange    = m_TargetRange;
             c.targetSoftness = m_TargetSoftness;
 
             c.srcBlendMode = m_SrcBlendMode;
             c.dstBlendMode = m_DstBlendMode;
 
-            c.shadowMode = m_ShadowMode;
-            c.shadowDistance = m_ShadowDistance;
-            c.shadowIteration = m_ShadowIteration;
-            c.shadowFade = m_ShadowFade;
-            c.shadowMirrorScale = m_ShadowMirrorScale;
+            c.shadowMode          = m_ShadowMode;
+            c.shadowDistance      = m_ShadowDistance;
+            c.shadowIteration     = m_ShadowIteration;
+            c.shadowFade          = m_ShadowFade;
+            c.shadowMirrorScale   = m_ShadowMirrorScale;
             c.shadowBlurIntensity = m_ShadowBlurIntensity;
-            c.shadowColorFilter = m_ShadowColorFilter;
-            c.shadowColor = m_ShadowColor;
-            c.shadowColorGlow = m_ShadowColorGlow;
+            c.shadowColorFilter   = m_ShadowColorFilter;
+            c.shadowColor         = m_ShadowColor;
+            c.shadowColorGlow     = m_ShadowColorGlow;
 
-            c.gradationMode = m_GradationMode;
-            c.gradationColor1 = m_GradationColor1;
-            c.gradationColor2 = m_GradationColor2;
+            c.gradationMode     = m_GradationMode;
+            c.gradationColor1   = m_GradationColor1;
+            c.gradationColor2   = m_GradationColor2;
             c.gradationGradient = m_GradationGradient;
-            c.gradationOffset = m_GradationOffset;
-            c.gradationScale = m_GradationScale;
+            c.gradationOffset   = m_GradationOffset;
+            c.gradationScale    = m_GradationScale;
             c.gradationRotation = m_GradationRotation;
 
             c.allowToModifyMeshShape = m_AllowToModifyMeshShape;
@@ -914,50 +922,50 @@ namespace Coffee.UIEffects
         {
             if (!preset) return;
 
-            m_ToneFilter = preset.m_ToneFilter;
+            m_ToneFilter    = preset.m_ToneFilter;
             m_ToneIntensity = preset.m_ToneIntensity;
-            m_ToneParams = preset.m_ToneParams;
+            m_ToneParams    = preset.m_ToneParams;
 
-            m_ColorFilter = preset.m_ColorFilter;
-            m_Color = preset.m_Color;
+            m_ColorFilter    = preset.m_ColorFilter;
+            m_Color          = preset.m_Color;
             m_ColorIntensity = preset.m_ColorIntensity;
-            m_ColorGlow = preset.m_ColorGlow;
+            m_ColorGlow      = preset.m_ColorGlow;
 
-            m_SamplingFilter = preset.m_SamplingFilter;
+            m_SamplingFilter    = preset.m_SamplingFilter;
             m_SamplingIntensity = preset.m_SamplingIntensity;
-            m_SamplingScale = preset.m_SamplingScale;
+            m_SamplingScale     = preset.m_SamplingScale;
 
-            m_TransitionFilter = preset.m_TransitionFilter;
-            m_TransitionRate = preset.m_TransitionRate;
-            m_TransitionReverse = preset.m_TransitionReverse;
-            m_TransitionTex = preset.m_TransitionTex;
-            m_TransitionTexScale = preset.m_TransitionTexScale;
-            m_TransitionTexOffset = preset.m_TransitionTexOffset;
-            m_TransitionRotation = preset.m_TransitionRotation;
+            m_TransitionFilter          = preset.m_TransitionFilter;
+            m_TransitionRate            = preset.m_TransitionRate;
+            m_TransitionReverse         = preset.m_TransitionReverse;
+            m_TransitionTex             = preset.m_TransitionTex;
+            m_TransitionTexScale        = preset.m_TransitionTexScale;
+            m_TransitionTexOffset       = preset.m_TransitionTexOffset;
+            m_TransitionRotation        = preset.m_TransitionRotation;
             m_TransitionKeepAspectRatio = preset.m_TransitionKeepAspectRatio;
-            m_TransitionWidth = preset.m_TransitionWidth;
-            m_TransitionSoftness = preset.m_TransitionSoftness;
-            m_TransitionColorFilter = preset.m_TransitionColorFilter;
-            m_TransitionColor = preset.m_TransitionColor;
-            m_TransitionColorGlow = preset.m_TransitionColorGlow;
+            m_TransitionWidth           = preset.m_TransitionWidth;
+            m_TransitionSoftness        = preset.m_TransitionSoftness;
+            m_TransitionColorFilter     = preset.m_TransitionColorFilter;
+            m_TransitionColor           = preset.m_TransitionColor;
+            m_TransitionColorGlow       = preset.m_TransitionColorGlow;
 
-            m_TargetMode = preset.m_TargetMode;
-            m_TargetColor = preset.m_TargetColor;
-            m_TargetRange = preset.m_TargetRange;
+            m_TargetMode     = preset.m_TargetMode;
+            m_TargetColor    = preset.m_TargetColor;
+            m_TargetRange    = preset.m_TargetRange;
             m_TargetSoftness = preset.m_TargetSoftness;
 
-            m_BlendType = preset.m_BlendType;
+            m_BlendType                      = preset.m_BlendType;
             (m_SrcBlendMode, m_DstBlendMode) = (m_BlendType, preset.m_SrcBlendMode, preset.m_DstBlendMode).Convert();
 
-            m_ShadowMode = preset.m_ShadowMode;
-            m_ShadowDistance = preset.m_ShadowDistance;
-            m_ShadowIteration = preset.m_ShadowIteration;
-            m_ShadowFade = preset.m_ShadowFade;
-            m_ShadowMirrorScale = preset.m_ShadowMirrorScale;
+            m_ShadowMode          = preset.m_ShadowMode;
+            m_ShadowDistance      = preset.m_ShadowDistance;
+            m_ShadowIteration     = preset.m_ShadowIteration;
+            m_ShadowFade          = preset.m_ShadowFade;
+            m_ShadowMirrorScale   = preset.m_ShadowMirrorScale;
             m_ShadowBlurIntensity = preset.m_ShadowBlurIntensity;
-            m_ShadowColorFilter = preset.m_ShadowColorFilter;
-            m_ShadowColor = preset.m_ShadowColor;
-            m_ShadowColorGlow = preset.m_ShadowColorGlow;
+            m_ShadowColorFilter   = preset.m_ShadowColorFilter;
+            m_ShadowColor         = preset.m_ShadowColor;
+            m_ShadowColorGlow     = preset.m_ShadowColorGlow;
 
             UpdateContext(context);
             ApplyContextToMaterial();
@@ -967,57 +975,57 @@ namespace Coffee.UIEffects
 
         internal void CopyFrom(UIEffectContext c)
         {
-            m_ToneFilter = c.toneFilter;
+            m_ToneFilter    = c.toneFilter;
             m_ToneIntensity = c.toneIntensity;
-            m_ToneParams = c.toneParams;
+            m_ToneParams    = c.toneParams;
 
-            m_ColorFilter = c.colorFilter;
-            m_Color = c.color;
+            m_ColorFilter    = c.colorFilter;
+            m_Color          = c.color;
             m_ColorIntensity = c.colorIntensity;
-            m_ColorGlow = c.colorGlow;
+            m_ColorGlow      = c.colorGlow;
 
-            m_SamplingFilter = c.samplingFilter;
+            m_SamplingFilter    = c.samplingFilter;
             m_SamplingIntensity = c.samplingIntensity;
 
-            m_TransitionFilter = c.transitionFilter;
-            m_TransitionRate = c.transitionRate;
-            m_TransitionReverse = c.transitionReverse;
-            m_TransitionTex = c.transitionTex;
-            m_TransitionTexScale = c.transitionTexScale;
-            m_TransitionTexOffset = c.transitionTexOffset;
-            m_TransitionRotation = c.transitionRotation;
+            m_TransitionFilter          = c.transitionFilter;
+            m_TransitionRate            = c.transitionRate;
+            m_TransitionReverse         = c.transitionReverse;
+            m_TransitionTex             = c.transitionTex;
+            m_TransitionTexScale        = c.transitionTexScale;
+            m_TransitionTexOffset       = c.transitionTexOffset;
+            m_TransitionRotation        = c.transitionRotation;
             m_TransitionKeepAspectRatio = c.transitionKeepAspectRatio;
-            m_TransitionWidth = c.transitionWidth;
-            m_TransitionSoftness = c.transitionSoftness;
-            m_TransitionColorFilter = c.transitionColorFilter;
-            m_TransitionColor = c.transitionColor;
-            m_TransitionColorGlow = c.transitionColorGlow;
+            m_TransitionWidth           = c.transitionWidth;
+            m_TransitionSoftness        = c.transitionSoftness;
+            m_TransitionColorFilter     = c.transitionColorFilter;
+            m_TransitionColor           = c.transitionColor;
+            m_TransitionColorGlow       = c.transitionColorGlow;
 
-            m_TargetMode = c.targetMode;
-            m_TargetColor = c.targetColor;
-            m_TargetRange = c.targetRange;
+            m_TargetMode     = c.targetMode;
+            m_TargetColor    = c.targetColor;
+            m_TargetRange    = c.targetRange;
             m_TargetSoftness = c.targetSoftness;
 
             m_SrcBlendMode = c.srcBlendMode;
             m_DstBlendMode = c.dstBlendMode;
-            m_BlendType = (m_SrcBlendMode, m_DstBlendMode).Convert();
+            m_BlendType    = (m_SrcBlendMode, m_DstBlendMode).Convert();
 
-            m_ShadowMode = c.shadowMode;
-            m_ShadowDistance = c.shadowDistance;
-            m_ShadowIteration = c.shadowIteration;
-            m_ShadowFade = c.shadowFade;
-            m_ShadowMirrorScale = c.shadowMirrorScale;
+            m_ShadowMode          = c.shadowMode;
+            m_ShadowDistance      = c.shadowDistance;
+            m_ShadowIteration     = c.shadowIteration;
+            m_ShadowFade          = c.shadowFade;
+            m_ShadowMirrorScale   = c.shadowMirrorScale;
             m_ShadowBlurIntensity = c.shadowBlurIntensity;
-            m_ShadowColorFilter = c.shadowColorFilter;
-            m_ShadowColor = c.shadowColor;
-            m_ShadowColorGlow = c.shadowColorGlow;
+            m_ShadowColorFilter   = c.shadowColorFilter;
+            m_ShadowColor         = c.shadowColor;
+            m_ShadowColorGlow     = c.shadowColorGlow;
 
-            m_GradationMode = c.gradationMode;
-            m_GradationColor1 = c.gradationColor1;
-            m_GradationColor2 = c.gradationColor2;
+            m_GradationMode     = c.gradationMode;
+            m_GradationColor1   = c.gradationColor1;
+            m_GradationColor2   = c.gradationColor2;
             m_GradationGradient = c.gradationGradient;
-            m_GradationOffset = c.gradationOffset;
-            m_GradationScale = c.gradationScale;
+            m_GradationOffset   = c.gradationOffset;
+            m_GradationScale    = c.gradationScale;
             m_GradationRotation = c.gradationRotation;
 
             m_AllowToModifyMeshShape = c.allowToModifyMeshShape;

--- a/Packages/src/Runtime/UIEffect.cs
+++ b/Packages/src/Runtime/UIEffect.cs
@@ -148,19 +148,11 @@ namespace Coffee.UIEffects
         protected GradationMode m_GradationMode = GradationMode.None;
 
         [SerializeField]
-#if UIEFFECTS_GRADIENT_NO_HDR
-        [ColorUsage(true)]
-#else
         [ColorUsage(true, true)]
-#endif
         protected Color m_GradationColor1 = Color.white;
 
         [SerializeField]
-#if UIEFFECTS_GRADIENT_NO_HDR
-        [ColorUsage(true)]
-#else
         [ColorUsage(true, true)]
-#endif
         protected Color m_GradationColor2 = Color.white;
 
         [SerializeField]

--- a/Packages/src/Runtime/UIEffect.cs
+++ b/Packages/src/Runtime/UIEffect.cs
@@ -148,18 +148,18 @@ namespace Coffee.UIEffects
         protected GradationMode m_GradationMode = GradationMode.None;
 
         [SerializeField]
-#if UIEFFECTS_GRADIENT_HDR
-        [ColorUsage(true, true)]
-#else
+#if UIEFFECTS_GRADIENT_NO_HDR
         [ColorUsage(true)]
+#else
+        [ColorUsage(true, true)]
 #endif
         protected Color m_GradationColor1 = Color.white;
 
         [SerializeField]
-#if UIEFFECTS_GRADIENT_HDR
-        [ColorUsage(true, true)]
-#else
+#if UIEFFECTS_GRADIENT_NO_HDR
         [ColorUsage(true)]
+#else
+        [ColorUsage(true, true)]
 #endif
         protected Color m_GradationColor2 = Color.white;
 

--- a/Packages/src/Runtime/UIEffectProjectSettings.cs
+++ b/Packages/src/Runtime/UIEffectProjectSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,6 +15,9 @@ namespace Coffee.UIEffects
         [Header("Setting")]
         [SerializeField]
         private TransformSensitivity m_TransformSensitivity = TransformSensitivity.Medium;
+
+        [Tooltip("Use HDR color pickers on color fields.")]
+        [SerializeField] private bool m_UseHdrColorPicker = true;
 
         [SerializeField]
         internal List<UIEffect> m_RuntimePresets = new List<UIEffect>();
@@ -36,6 +38,12 @@ namespace Coffee.UIEffects
         {
             get => instance.m_TransformSensitivity;
             set => instance.m_TransformSensitivity = value;
+        }
+
+        public static bool useHdrColorPicker
+        {
+            get => instance.m_UseHdrColorPicker;
+            set => instance.m_UseHdrColorPicker = value;
         }
 
         public static void RegisterRuntimePreset(UIEffect effect)
@@ -113,7 +121,7 @@ namespace Coffee.UIEffects
             m_ShaderVariantRegistry.ClearCache();
             MaterialRepository.Clear();
             foreach (var c in Misc.FindObjectsOfType<UIEffectBase>()
-                         .Concat(Misc.GetAllComponentsInPrefabStage<UIEffectBase>()))
+                .Concat(Misc.GetAllComponentsInPrefabStage<UIEffectBase>()))
             {
                 c.SetMaterialDirty();
             }

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 24
+  serializedVersion: 23
   productGUID: 0b1ee023fb82a4c58a1b7381ccae9ac1
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
@@ -121,7 +121,6 @@ PlayerSettings:
   switchNVNOtherPoolsGranularity: 16777216
   switchNVNMaxPublicTextureIDCount: 0
   switchNVNMaxPublicSamplerIDCount: 0
-  switchMaxWorkerMultiple: 8
   stadiaPresentMode: 0
   stadiaTargetFramerate: 0
   vulkanNumSwapchainBuffers: 3
@@ -148,7 +147,6 @@ PlayerSettings:
     enable360StereoCapture: 0
   isWsaHolographicRemotingEnabled: 0
   enableFrameTimingStats: 0
-  enableOpenGLProfilerGPURecorders: 1
   useHDRDisplay: 0
   D3DHDRBitDepth: 0
   m_ColorGamuts: 00000000
@@ -221,7 +219,6 @@ PlayerSettings:
   iOSLaunchScreeniPadCustomStoryboardPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
-  macOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
   metalEditorSupport: 1
@@ -464,7 +461,6 @@ PlayerSettings:
       m_Kind: 0
       m_SubKind: 
   m_BuildTargetBatching: []
-  m_BuildTargetShaderSettings: []
   m_BuildTargetGraphicsJobs: []
   m_BuildTargetGraphicsJobMode: []
   m_BuildTargetGraphicsAPIs:
@@ -475,8 +471,6 @@ PlayerSettings:
     m_APIs: 0b00000008000000
     m_Automatic: 0
   m_BuildTargetVRSettings: []
-  m_DefaultShaderChunkSizeInMB: 16
-  m_DefaultShaderChunkCount: 0
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
   openGLRequireES32: 0
@@ -488,7 +482,6 @@ PlayerSettings:
   m_BuildTargetGroupLightmapEncodingQuality: []
   m_BuildTargetGroupLightmapSettings: []
   m_BuildTargetNormalMapEncoding: []
-  m_BuildTargetDefaultTextureCompressionFormat: []
   playModeTestRunnerEnabled: 0
   runPlayModeTestAsEditModeTest: 0
   actionOnDotNetUnhandledException: 1
@@ -507,7 +500,6 @@ PlayerSettings:
   switchScreenResolutionBehavior: 2
   switchUseCPUProfiler: 0
   switchUseGOLDLinker: 0
-  switchLTOSetting: 0
   switchApplicationID: 0x01004b9000490000
   switchNSODependencies: 
   switchTitleNames_0: 
@@ -583,6 +575,7 @@ PlayerSettings:
   switchReleaseVersion: 0
   switchDisplayVersion: 1.0.0
   switchStartupUserAccount: 0
+  switchTouchScreenUsage: 0
   switchSupportedLanguagesMask: 0
   switchLogoType: 0
   switchApplicationErrorCodeCategory: 
@@ -624,7 +617,6 @@ PlayerSettings:
   switchNativeFsCacheSize: 32
   switchIsHoldTypeHorizontal: 0
   switchSupportedNpadCount: 8
-  switchEnableTouchScreen: 1
   switchSocketConfigEnabled: 0
   switchTcpInitialSendBufferSize: 32
   switchTcpInitialReceiveBufferSize: 64
@@ -737,21 +729,9 @@ PlayerSettings:
   webGLLinkerTarget: 1
   webGLThreadsSupport: 0
   webGLDecompressionFallback: 0
-  webGLPowerPreference: 2
   scriptingDefineSymbols:
-    Android: UNITY_POST_PROCESSING_STACK_V2
-    EmbeddedLinux: UNITY_POST_PROCESSING_STACK_V2
-    GameCoreXboxOne: UNITY_POST_PROCESSING_STACK_V2
-    Lumin: UNITY_POST_PROCESSING_STACK_V2
-    Nintendo Switch: UNITY_POST_PROCESSING_STACK_V2
-    PS4: UNITY_POST_PROCESSING_STACK_V2
-    PS5: UNITY_POST_PROCESSING_STACK_V2
-    Stadia: UNITY_POST_PROCESSING_STACK_V2
-    Standalone: UNITY_POST_PROCESSING_STACK_V2
-    WebGL: UNITY_POST_PROCESSING_STACK_V2
-    Windows Store Apps: UNITY_POST_PROCESSING_STACK_V2
-    XboxOne: UNITY_POST_PROCESSING_STACK_V2
-    tvOS: UNITY_POST_PROCESSING_STACK_V2
+    0: UNITY_POST_PROCESSING_STACK_V2
+    1: 
   additionalCompilerArguments: {}
   platformArchitecture: {}
   scriptingBackend: {}
@@ -774,6 +754,7 @@ PlayerSettings:
   suppressCommonWarnings: 1
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
+  useReferenceAssemblies: 1
   enableRoslynAnalyzers: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
@@ -861,6 +842,4 @@ PlayerSettings:
   organizationId: 
   cloudEnabled: 0
   legacyClampBlendShapeWeights: 0
-  playerDataPath: 
-  forceSRGBBlit: 1
   virtualTexturingSupportEnabled: 0


### PR DESCRIPTION
## Description

### Summary

Added an option to use non-HDR color fields on gradation color 1 and 2

### Motivation

In some versions of Unity, HDR color pickers doesn't have a HEX color field. This makes pasting colors somewhat difficult if a game uses an external design software.

Additionally, HDR color pickers may not be in the same color space as the non-HDR color fields, making the color in the field preview inaccurate.

### Dependencies

None added

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [X] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor(Windows)
- Unity version: 2020.3.48f1
- Build options: Mono, .Net Standard 2.0, BIRP

## Checklist

- [X] This pull request is for merging into the `develop` branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

![image](https://github.com/user-attachments/assets/e9938d45-ccb1-4e8a-819d-01329cda637a)
