### PR TITLE
feat: add option to remove from preloadedAssets when build player

### DIFF
--- a/Packages/src/CHANGELOG.md
+++ b/Packages/src/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Features
+
+* add `Exclude From Preloaded Assets When Build Player` option: temporarily removes settings from `PlayerSettings.preloadedAssets` during Player Build only, enabling AssetBundle / Addressables hot-update workflows while keeping normal Editor behavior unchanged
+
 ## [5.10.8](https://github.com/mob-sakai/UIEffect/compare/5.10.7...5.10.8) (2026-01-16)
 
 

--- a/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
+++ b/Packages/src/Editor/UIEffectProjectSettingsEditor.cs
@@ -95,6 +95,33 @@ namespace Coffee.UIEffects.Editors
             }
 
             _shaderVariantRegistryEditor.Draw();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Advanced", EditorStyles.boldLabel);
+            var excludeProp = serializedObject.FindProperty("m_ExcludeFromPreloadedAssetsWhenBuildPlayer");
+            EditorGUILayout.PropertyField(excludeProp);
+
+            if (excludeProp.boolValue)
+            {
+                var shadersProp = serializedObject.FindProperty("m_ShaderVariantRegistry")
+                    .FindPropertyRelative("m_RegisteredShaders");
+                EditorGUI.BeginDisabledGroup(true);
+                EditorGUI.indentLevel++;
+                for (var i = 0; i < shadersProp.arraySize; i++)
+                {
+                    EditorGUILayout.PropertyField(shadersProp.GetArrayElementAtIndex(i), GUIContent.none);
+                }
+                EditorGUI.indentLevel--;
+                EditorGUI.EndDisabledGroup();
+
+                if (shadersProp.arraySize == 0)
+                {
+                    EditorGUILayout.HelpBox(
+                        "No shaders registered. Re-import or modify the settings asset to trigger sync.",
+                        MessageType.Warning);
+                }
+            }
+
             GUILayout.FlexibleSpace();
             serializedObject.ApplyModifiedProperties();
         }

--- a/Packages/src/README.md
+++ b/Packages/src/README.md
@@ -629,6 +629,13 @@ You can adjust the project-wide settings for UIEffect. (`Edit > Project Settings
 > - The setting file is usually saved in `Assets/ProjectSettings/UIEffectProjectSettings.asset`. Include this file in your version control system.
 > - The setting file is automatically added as a preloaded asset in `ProjectSettings/ProjectSettings.asset`.
 
+#### Advanced
+
+- **Exclude From Preloaded Assets When Build Player**: When enabled, the settings asset will be **temporarily removed** from `PlayerSettings.preloadedAssets` **during Player Build only**, so it is NOT included in the built player. The asset remains in PreloadedAssets during normal Editor operation.
+  - Use this for AssetBundle / Addressables based hot-update workflows where settings and shaders are delivered externally instead of being built into the player.
+  - Shader references are serialized from the `ShaderVariantCollection` at edit-time, so `Shader.Find()` is not required at runtime.
+  - When toggled off, serialized shader references are automatically cleared.
+
 <br><br>
 
 ### :warning: Limitations

--- a/Packages/src/Runtime/Internal/ProjectSettings/PreloadedProjectSettings.cs
+++ b/Packages/src/Runtime/Internal/ProjectSettings/PreloadedProjectSettings.cs
@@ -14,11 +14,83 @@ namespace Coffee.UIEffectInternal
     public abstract class PreloadedProjectSettings : ScriptableObject
 #if UNITY_EDITOR
     {
+        [Tooltip("When enabled, this settings asset will be temporarily removed from " +
+                 "PlayerSettings.preloadedAssets during Player Build, so it is NOT included " +
+                 "in the built player. The asset remains in PreloadedAssets during normal " +
+                 "Editor operation.\n\n" +
+                 "Enable this when you deliver settings and shaders via AssetBundles or " +
+                 "Addressables for hot-update support. Shaders are then resolved via direct " +
+                 "serialized references instead of Shader.Find().")]
+        [SerializeField]
+        private bool m_ExcludeFromPreloadedAssetsWhenBuildPlayer;
+
+        /// <summary>
+        /// When enabled, this settings asset will be temporarily removed from
+        /// <see cref="PlayerSettings.preloadedAssets"/> only during Player Build,
+        /// so it is NOT included in the built player. The asset remains in
+        /// PreloadedAssets during normal Editor operation.
+        /// <para>
+        /// Enable this when you deliver settings and shaders via AssetBundles or
+        /// Addressables for hot-update support. Shaders are resolved via direct
+        /// serialized references in the shader variant registry instead of
+        /// <see cref="Shader.Find"/>, since AB-loaded shaders are not registered
+        /// in the global shader name table.
+        /// </para>
+        /// </summary>
+        public bool excludeFromPreloadedAssetsWhenBuildPlayer
+        {
+            get => m_ExcludeFromPreloadedAssetsWhenBuildPlayer;
+            set => m_ExcludeFromPreloadedAssetsWhenBuildPlayer = value;
+        }
+
+        protected static bool s_BuildingPlayer;
+
         private class Postprocessor : AssetPostprocessor
         {
             private static void OnPostprocessAllAssets(string[] _, string[] __, string[] ___, string[] ____)
             {
                 Initialize();
+            }
+        }
+
+        private class ExcludeFromBuild : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+        {
+            int IOrderedCallback.callbackOrder => -1;
+
+            void IPreprocessBuildWithReport.OnPreprocessBuild(BuildReport report)
+            {
+                s_BuildingPlayer = true;
+
+                foreach (var t in TypeCache.GetTypesDerivedFrom(typeof(PreloadedProjectSettings<>)))
+                {
+                    var settings = GetDefaultSettings(t);
+                    if (!settings || !settings.m_ExcludeFromPreloadedAssetsWhenBuildPlayer) continue;
+
+                    PlayerSettings.SetPreloadedAssets(
+                        PlayerSettings.GetPreloadedAssets()
+                            .Where(x => x && x.GetType() != t)
+                            .ToArray());
+
+                    Debug.Log($"[PreloadedProjectSettings] Build started: removed '{settings.name}' " +
+                              $"({t.Name}) from PreloadedAssets. " +
+                              $"It will be restored after build completes.");
+                }
+            }
+
+            void IPostprocessBuildWithReport.OnPostprocessBuild(BuildReport report)
+            {
+                s_BuildingPlayer = false;
+
+                Initialize();
+
+                foreach (var t in TypeCache.GetTypesDerivedFrom(typeof(PreloadedProjectSettings<>)))
+                {
+                    var settings = GetDefaultSettings(t);
+                    if (!settings || !settings.m_ExcludeFromPreloadedAssetsWhenBuildPlayer) continue;
+
+                    Debug.Log($"[PreloadedProjectSettings] Build finished: restored '{settings.name}' " +
+                              $"({t.Name}) to PreloadedAssets.");
+                }
             }
         }
 
@@ -41,11 +113,11 @@ namespace Coffee.UIEffectInternal
                 {
                     // When create a new instance, automatically set it as default settings.
                     defaultSettings = CreateInstance(t) as PreloadedProjectSettings;
-                    SetDefaultSettings(defaultSettings);
+                    if (!s_BuildingPlayer) SetDefaultSettings(defaultSettings);
                 }
                 else if (GetPreloadedSettings(t).Length != 1)
                 {
-                    SetDefaultSettings(defaultSettings);
+                    if (!s_BuildingPlayer) SetDefaultSettings(defaultSettings);
                 }
 
                 if (defaultSettings)
@@ -151,7 +223,7 @@ namespace Coffee.UIEffectInternal
                     return s_Instance;
                 }
 
-                SetDefaultSettings(s_Instance);
+                if (!s_BuildingPlayer) SetDefaultSettings(s_Instance);
                 return s_Instance;
             }
         }

--- a/Packages/src/Runtime/Internal/Utilities/ShaderVariantRegistry.cs
+++ b/Packages/src/Runtime/Internal/Utilities/ShaderVariantRegistry.cs
@@ -45,12 +45,16 @@ namespace Coffee.UIEffectInternal
         }
 
         private Dictionary<int, string> _cachedOptionalShaders = new Dictionary<int, string>();
+        private Dictionary<string, Shader> _shaderByName;
 
         [SerializeField]
         private List<StringPair> m_OptionalShaders = new List<StringPair>();
 
         [SerializeField]
         internal ShaderVariantCollection m_Asset;
+
+        [SerializeField]
+        private List<Shader> m_RegisteredShaders = new List<Shader>();
 
 #if UNITY_EDITOR
         [SerializeField]
@@ -63,6 +67,43 @@ namespace Coffee.UIEffectInternal
         public ShaderVariantCollection shaderVariantCollection => m_Asset;
         public Func<string, bool> onShaderRequested;
 
+        /// <summary>
+        /// Build the runtime name-to-shader lookup from <see cref="m_RegisteredShaders"/>.
+        /// When shaders are delivered via AssetBundles (i.e. not in the player build),
+        /// <see cref="Shader.Find"/> cannot locate them by name. This lookup provides
+        /// direct references serialized at edit-time as a reliable alternative.
+        /// </summary>
+        public void InitializeShaderLookup()
+        {
+            var count = m_RegisteredShaders.Count;
+            if (count == 0) return;
+
+            if (_shaderByName == null)
+                _shaderByName = new Dictionary<string, Shader>(count);
+            else
+                _shaderByName.Clear();
+
+            for (var i = 0; i < count; i++)
+            {
+                var s = m_RegisteredShaders[i];
+                if (s)
+                    _shaderByName[s.name] = s;
+            }
+        }
+
+        /// <summary>
+        /// Find a shader by name. Prefers the registered direct reference from
+        /// <see cref="m_RegisteredShaders"/> when available, falls back to
+        /// <see cref="Shader.Find"/> otherwise. This ensures correct behavior in both
+        /// built-in delivery (PreloadedAssets) and external delivery (AssetBundle) modes.
+        /// </summary>
+        public Shader FindShaderByName(string name)
+        {
+            if (_shaderByName != null && _shaderByName.TryGetValue(name, out var shader) && shader)
+                return shader;
+            return Shader.Find(name);
+        }
+
         public Shader FindOptionalShader(Shader shader,
             string requiredName,
             string format,
@@ -74,7 +115,7 @@ namespace Coffee.UIEffectInternal
             var id = shader.GetInstanceID();
             if (_cachedOptionalShaders.TryGetValue(id, out var optionalShaderName))
             {
-                return Shader.Find(optionalShaderName);
+                return FindShaderByName(optionalShaderName);
             }
 
             // The shader has required name.
@@ -92,7 +133,7 @@ namespace Coffee.UIEffectInternal
             {
                 var pair = m_OptionalShaders[i];
                 if (pair.key != shaderName) continue;
-                optionalShader = Shader.Find(pair.value);
+                optionalShader = FindShaderByName(pair.value);
                 if (!optionalShader) continue;
                 _cachedOptionalShaders[id] = pair.value;
                 return optionalShader;
@@ -100,7 +141,7 @@ namespace Coffee.UIEffectInternal
 
             // Find optional shader by format.
             optionalShaderName = string.Format(format, shaderName);
-            optionalShader = Shader.Find(optionalShaderName);
+            optionalShader = FindShaderByName(optionalShaderName);
             if (optionalShader)
             {
                 _cachedOptionalShaders[id] = optionalShaderName;
@@ -110,13 +151,13 @@ namespace Coffee.UIEffectInternal
 #if UNITY_EDITOR
             if (onShaderRequested?.Invoke(optionalShaderName) ?? false)
             {
-                return Shader.Find(defaultOptionalShaderName);
+                return FindShaderByName(defaultOptionalShaderName);
             }
 #endif
 
             // Find default optional shader.
             _cachedOptionalShaders[id] = defaultOptionalShaderName;
-            return Shader.Find(defaultOptionalShaderName);
+            return FindShaderByName(defaultOptionalShaderName);
         }
 
 #if UNITY_EDITOR
@@ -208,8 +249,46 @@ namespace Coffee.UIEffectInternal
                 AssetDatabase.SaveAssets();
             }
 
+            SyncRegisteredShaders(owner);
             ClearCache();
             Profiler.EndSample();
+        }
+
+        /// <summary>
+        /// Sync <see cref="m_RegisteredShaders"/> based on the current delivery mode.
+        /// When <see cref="PreloadedProjectSettings.excludeFromPreloadedAssetsWhenBuildPlayer"/> is enabled,
+        /// extracts shader references from the SVC so they can be resolved at runtime
+        /// without <see cref="Shader.Find"/>. Otherwise clears the list to avoid
+        /// stale references and unnecessary asset dependencies.
+        /// </summary>
+        private void SyncRegisteredShaders(Object owner)
+        {
+            var settings = owner as PreloadedProjectSettings;
+            var needsDirectRef = settings && settings.excludeFromPreloadedAssetsWhenBuildPlayer;
+
+            if (!needsDirectRef || !m_Asset)
+            {
+                if (m_RegisteredShaders.Count > 0)
+                {
+                    m_RegisteredShaders.Clear();
+                    EditorUtility.SetDirty(owner);
+                }
+                return;
+            }
+
+            var so = new SerializedObject(m_Asset);
+            var shaders = so.FindProperty("m_Shaders");
+            m_RegisteredShaders.Clear();
+            for (var i = 0; i < shaders.arraySize; i++)
+            {
+                var shaderRef = shaders.GetArrayElementAtIndex(i)
+                    .FindPropertyRelative("first")
+                    .objectReferenceValue as Shader;
+                if (shaderRef && !m_RegisteredShaders.Contains(shaderRef))
+                    m_RegisteredShaders.Add(shaderRef);
+            }
+
+            EditorUtility.SetDirty(owner);
         }
 
         internal void RegisterVariant(Material material, string path)

--- a/Packages/src/Runtime/UIEffectProjectSettings.cs
+++ b/Packages/src/Runtime/UIEffectProjectSettings.cs
@@ -83,6 +83,14 @@ namespace Coffee.UIEffects
 #pragma warning restore CS0618
         }
 
+#if !UNITY_EDITOR
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            m_ShaderVariantRegistry.InitializeShaderLookup();
+        }
+#endif
+
 #if UNITY_EDITOR
         private const string k_PresetDir = "UIEffectPresets";
         private const string k_PresetSaveDir = "Assets/ProjectSettings/" + k_PresetDir;
@@ -212,6 +220,7 @@ namespace Coffee.UIEffects
         protected override void OnEnable()
         {
             base.OnEnable();
+            m_ShaderVariantRegistry.InitializeShaderLookup();
             m_ShaderVariantRegistry.onShaderRequested = ShaderSampleImporter.ImportShaderIfSelected;
             m_ShaderVariantRegistry.ClearCache();
         }


### PR DESCRIPTION
## Description

Add `Exclude From Preloaded Assets When Build Player` option to support AssetBundle / Addressables hot-update workflows.

When enabled, the settings asset is **temporarily removed** from `PlayerSettings.preloadedAssets` during Player Build only, so it is NOT included in the built player. The asset remains in PreloadedAssets during normal Editor operation — all original auto-create, auto-register, and singleton behaviors are completely unchanged.

At runtime, shaders loaded from AssetBundles cannot be found via `Shader.Find()`. To address this, shader references are extracted from the `ShaderVariantCollection` at edit-time and serialized into a flat `List<Shader>`. At runtime, `FindShaderByName()` resolves shaders from this list first, falling back to `Shader.Find()` only when no match is found.

### How it works

1. **Editor**: Settings always stay in PreloadedAssets. Zero behavioral difference from upstream.
2. **PreprocessBuild (callbackOrder=-1)**: Sets `s_BuildingPlayer = true`, removes excluded settings from PreloadedAssets, logs the action.
3. **PreprocessBuild (callbackOrder=0, original)**: Calls `Initialize()`. The `s_BuildingPlayer` guard prevents `SetDefaultSettings()` from restoring PreloadedAssets.
4. **Build proceeds**: Any `AssetPostprocessor` or `instance` getter that triggers `SetDefaultSettings()` is also guarded.
5. **PostprocessBuild (callbackOrder=-1)**: Sets `s_BuildingPlayer = false`, calls `Initialize()` to restore PreloadedAssets, logs the action.

### Changed files

- `PreloadedProjectSettings.cs` — new `m_ExcludeFromPreloadedAssetsWhenBuildPlayer` field, `s_BuildingPlayer` static flag, `ExcludeFromBuild` inner class (`IPreprocessBuildWithReport` + `IPostprocessBuildWithReport`), guard in `Initialize()` and `instance` getter
- `ShaderVariantRegistry.cs` — `m_RegisteredShaders` field, `InitializeShaderLookup()`, `FindShaderByName()`, `SyncRegisteredShaders()`
- `UIEffectProjectSettings.cs` — call `InitializeShaderLookup()` in `OnEnable`
- `UIEffectProjectSettingsEditor.cs` — expose the new option and registered shaders list in Inspector
- `CHANGELOG.md` / `README.md` — document the new feature

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Test environment

- Platform: Editor (Windows), Android
- Unity version: 2022.3 LTS
- Build options: IL2CPP, .NET Standard 2.1

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings