### PR TITLE
Fix XBox shader compilation error

### DIFF
--- a/Packages/src/Shaders/UIEffect.cginc
+++ b/Packages/src/Shaders/UIEffect.cginc
@@ -94,8 +94,8 @@ uniform const matrix _CanvasToWorldMatrix;
 #endif
 
 #define UIEFFECT_UV_MASK(uv, uvMask) step(uvMask.x, uv.x) * step(uv.x, uvMask.z) * step(uvMask.y, uv.y) * step(uv.y, uvMask.w)
-#define UIEFFECT_SAMPLE(uv) uieffect_frag(uv)
-#define UIEFFECT_SAMPLE_CLAMP(uv, uvMask) uieffect_frag(uv) * UIEFFECT_UV_MASK(uv, uvMask)
+#define UIEFFECT_SAMPLE(uv, inColor) uieffect_frag(uv, inColor)
+#define UIEFFECT_SAMPLE_CLAMP(uv, uvMask, inColor) uieffect_frag(uv, inColor) * UIEFFECT_UV_MASK(uv, uvMask)
 
 #ifdef CANVAS_SHADERGRAPH
 #define TEX_SAMPLE_CLAMP(uv, uvMask) SAMPLE_TEXTURE2D(_MainTex, sampler_MainTex, uv) * UIEFFECT_UV_MASK(uv, uvMask)
@@ -273,7 +273,7 @@ half4 apply_color_filter(int mode, half4 inColor, half4 factor, float intensity,
     return color;
 }
 
-half4 apply_sampling_filter(float2 uv, const float4 uvMask, const float isShadow)
+half4 apply_sampling_filter(float2 uv, const float4 uvMask, const float isShadow, fixed4 inColor)
 {
     #if SAMPLING_BLUR_FAST || SAMPLING_BLUR_MEDIUM || SAMPLING_BLUR_DETAIL
     {
@@ -305,7 +305,7 @@ half4 apply_sampling_filter(float2 uv, const float4 uvMask, const float isShadow
                     const float weight = KERNEL_[x] * KERNEL_[y]
                         * step(uvMask.x, bluredUv.x) * step(bluredUv.x, uvMask.z)
                         * step(uvMask.y, bluredUv.y) * step(bluredUv.y, uvMask.w);
-                    o += UIEFFECT_SAMPLE(bluredUv) * weight;
+                    o += UIEFFECT_SAMPLE(bluredUv, inColor) * weight;
                     sum += weight;
                 }
             }
@@ -315,7 +315,7 @@ half4 apply_sampling_filter(float2 uv, const float4 uvMask, const float isShadow
     }
     #endif
 
-    return UIEFFECT_SAMPLE_CLAMP(uv, uvMask);
+    return UIEFFECT_SAMPLE_CLAMP(uv, uvMask, inColor);
 }
 
 float2 move_transition_filter(const float4 uvMask, const float alpha)
@@ -552,12 +552,12 @@ float is_edge_shiny(const float2 uvLocal)
     #endif
 }
 
-half4 uieffect_internal(float2 uv, float4 uvMask, const float2 uvLocal, const float2 uvGrad, const float isShadow)
+half4 uieffect_internal(float2 uv, float4 uvMask, const float2 uvLocal, const float2 uvGrad, const float isShadow, fixed4 inColor)
 {
     const half alpha = transition_alpha(uvLocal);
     const float edgeFactor = edge(uv, uvMask, _EdgeWidth);
     uv += move_transition_filter(uvMask, alpha);
-    half4 color = apply_sampling_filter(uv, uvMask, isShadow);
+    half4 color = apply_sampling_filter(uv, uvMask, isShadow, inColor);
     color = apply_gradation_filter(color, uvGrad);
     color = apply_tone_filter(color);
     color = apply_transition_filter(color, alpha, uvLocal, edgeFactor);
@@ -584,7 +584,7 @@ half4 uieffect_internal(float2 uv, float4 uvMask, const float2 uvLocal, const fl
     }
 }
 
-half4 uieffect(half4 origin, float2 uv, float4 uvMask, float4 wpos)
+half4 uieffect(half4 origin, float2 uv, float4 uvMask, float4 wpos, fixed4 inColor)
 {
     #ifdef NO_UIEFFECT
     return origin;
@@ -622,9 +622,9 @@ half4 uieffect(half4 origin, float2 uv, float4 uvMask, float4 wpos)
     #elif SAMPLING_RGB_SHIFT
     {
         const half2 offset = half2(_SamplingIntensity * texel_size().x * 20, 0);
-        const half2 r = uieffect_internal(uv + offset, uvMask, uvLocal, uvGrad, isShadow).ra;
-        const half2 g = uieffect_internal(uv, uvMask, uvLocal, uvGrad, isShadow).ga;
-        const half2 b = uieffect_internal(uv - offset, uvMask, uvLocal, uvGrad, isShadow).ba;
+        const half2 r = uieffect_internal(uv + offset, uvMask, uvLocal, uvGrad, isShadow, inColor).ra;
+        const half2 g = uieffect_internal(uv, uvMask, uvLocal, uvGrad, isShadow, inColor).ga;
+        const half2 b = uieffect_internal(uv - offset, uvMask, uvLocal, uvGrad, isShadow, inColor).ba;
         return half4(r.x * r.y, g.x * g.y, b.x * b.y, (r.y + g.y + b.y) / 3);
     }
     // Sampling.EdgeLuminance/EdgeAlpha
@@ -634,32 +634,32 @@ half4 uieffect(half4 origin, float2 uv, float4 uvMask, float4 wpos)
         const float2 d = texel_size() * _SamplingWidth;
 
         // Pixel values around the current pixel (3x3, 8 neighbors)
-        const half v00 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(-d.x, -d.y)), uvMask));
-        const half v01 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(-d.x, 0.0)), uvMask));
-        const half v02 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(-d.x, +d.y)), uvMask));
-        const half v10 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(0.0, -d.y)), uvMask));
-        const half v12 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(0.0, +d.y)), uvMask));
-        const half v20 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(+d.x, -d.y)), uvMask));
-        const half v21 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(+d.x, 0.0)), uvMask));
-        const half v22 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(+d.x, +d.y)), uvMask));
+        const half v00 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(-d.x, -d.y)), uvMask, inColor));
+        const half v01 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(-d.x, 0.0)), uvMask, inColor));
+        const half v02 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(-d.x, +d.y)), uvMask, inColor));
+        const half v10 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(0.0, -d.y)), uvMask, inColor));
+        const half v12 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(0.0, +d.y)), uvMask, inColor));
+        const half v20 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(+d.x, -d.y)), uvMask, inColor));
+        const half v21 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(+d.x, 0.0)), uvMask, inColor));
+        const half v22 = to_value(UIEFFECT_SAMPLE_CLAMP((uv + half2(+d.x, +d.y)), uvMask, inColor));
 
         // Apply Sobel operator
         half sobel_h = v00 * -1.0 + v01 * -2.0 + v02 * -1.0 + v20 * 1.0 + v21 * 2.0 + v22 * 1.0;
         half sobel_v = v00 * -1.0 + v10 * -2.0 + v20 * -1.0 + v02 * 1.0 + v12 * 2.0 + v22 * 1.0;
 
         const half sobel = sqrt(sobel_h * sobel_h + sobel_v * sobel_v) * _SamplingIntensity;
-        return lerp(0, uieffect_internal(uv, uvMask, uvLocal, uvGrad, isShadow), inv_lerp(0.5, 1, sobel));
+        return lerp(0, uieffect_internal(uv, uvMask, uvLocal, uvGrad, isShadow, inColor), inv_lerp(0.5, 1, sobel));
     }
     #endif
 
-    return lerp(origin, uieffect_internal(uv, uvMask, uvLocal, uvGrad, isShadow), rate);
+    return lerp(origin, uieffect_internal(uv, uvMask, uvLocal, uvGrad, isShadow, inColor), rate);
 }
 
 
-half4 uieffect(float2 uv, float4 uvMask, float4 wpos)
+half4 uieffect(float2 uv, float4 uvMask, float4 wpos, fixed4 inColor)
 {
-    const half4 origin = UIEFFECT_SAMPLE_CLAMP(uv, uvMask);
-    return uieffect(origin, uv, uvMask, wpos);
+    const half4 origin = UIEFFECT_SAMPLE_CLAMP(uv, uvMask, inColor);
+    return uieffect(origin, uv, uvMask, wpos, inColor);
 }
 
 #endif // UI_EFFECT_INCLUDED

--- a/Packages/src/Shaders/UIEffect.shader
+++ b/Packages/src/Shaders/UIEffect.shader
@@ -147,12 +147,10 @@ Shader "Hidden/UI/Default (UIEffect)"
             }
 
             // ==== UIEFFECT START ====
-            v2f _fragInput;
-            fixed4 uieffect_frag(float2 uv)
+            fixed4 uieffect_frag(float2 uv, fixed4 inColor)
             {
-                v2f IN = _fragInput;
                 half4 color = (tex2D(_MainTex, uv) + _TextureSampleAdd);
-                color.rgb *= IN.color.rgb;
+                color.rgb *= inColor.rgb;
                 color.rgb *= color.a;
                 return color;
             }
@@ -169,8 +167,7 @@ Shader "Hidden/UI/Default (UIEffect)"
                 const half invAlphaPrecision = half(1.0 / alphaPrecision);
                 IN.color.a = round(IN.color.a * alphaPrecision) * invAlphaPrecision;
 
-                _fragInput = IN;
-                half4 c = uieffect(IN.texcoord, IN.uvMask, IN.worldPosition);
+                half4 c = uieffect(IN.texcoord, IN.uvMask, IN.worldPosition, IN.color);
                 c *= IN.color.a;
 
                 #ifdef UNITY_UI_CLIP_RECT

--- a/Packages/src/Shaders/UIEffect.shader
+++ b/Packages/src/Shaders/UIEffect.shader
@@ -165,7 +165,7 @@ Shader "Hidden/UI/Default (UIEffect)"
                 //Round up the alpha color coming from the interpolator (to 1.0/256.0 steps)
                 //The incoming alpha could have numerical instability, which makes it very sensible to
                 //HDR color transparency blend, when it blends with the world's texture.
-                const half alphaPrecision = half(0xff);
+                const half alphaPrecision = 255.0h;
                 const half invAlphaPrecision = half(1.0 / alphaPrecision);
                 IN.color.a = round(IN.color.a * alphaPrecision) * invAlphaPrecision;
 


### PR DESCRIPTION
## Description

The UIEffect doesn't work correctly on XBox because the compiler doesn't like that it's using a global variable in the fragment shader. The error is:

`Shader error in 'Hidden/UI/Default (UIEffect)': Program 'frag', error: llvm::cast<X>() argument of incompatible type! (on gamecore_scarlett)`

## Type of change

- [*] Bug fix (non-breaking change which fixes an issue)  

I've removed the global variable in the fragment shader and now pass the color around in the function chain.

## Test environment

- Platform: XBox Series X/S
- Unity version: 6000.4.0f1
- IL2CPP

## Checklist

- [*] This pull request is for merging into the `develop` branch
- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] My changes generate no new warnings
