### PR TITLE
fix: select TMP submesh by mesh before material

### DIFF
--- a/Packages/src/Runtime/Utilities/TmpProxy.cs
+++ b/Packages/src/Runtime/Utilities/TmpProxy.cs
@@ -239,7 +239,7 @@ namespace Coffee.UIEffects
                     }
                     else
                     {
-                        var subMeshUI = GetSubMeshUI(subMeshes, meshInfo.material, i - 1);
+                        var subMeshUI = GetSubMeshUI(subMeshes, meshInfo.material, meshInfo.mesh, i - 1);
                         if (subMeshUI)
                         {
                             subMeshUI.canvasRenderer.SetMesh(s_Mesh);
@@ -269,7 +269,7 @@ namespace Coffee.UIEffects
                         modifier.ModifyMesh(s_VertexHelper);
                     }
 
-                    var subMeshUI = GetSubMeshUI(subMeshes, meshInfo.material, i - 1);
+                    var subMeshUI = GetSubMeshUI(subMeshes, meshInfo.material, meshInfo.mesh, i - 1);
                     if (!subMeshUI) break;
 
                     // fix: TMP Text sprite submesh lost when changing fontMaterial (#368)
@@ -323,12 +323,23 @@ namespace Coffee.UIEffects
             Misc.QueuePlayerLoopUpdate();
         }
 
-        private static TMP_SubMeshUI GetSubMeshUI(List<TMP_SubMeshUI> subMeshes, Material material, int start)
+        private static TMP_SubMeshUI GetSubMeshUI(List<TMP_SubMeshUI> subMeshes, Material material, Mesh mesh, int start)
         {
             var count = subMeshes.Count;
+            if (mesh)
+            {
+                for (var j = 0; j < count; j++)
+                {
+                    var s = subMeshes[(j + start + count) % count];
+                    if (!s) continue;
+                    if (s.mesh == mesh) return s;
+                }
+            }
+
             for (var j = 0; j < count; j++)
             {
                 var s = subMeshes[(j + start + count) % count];
+                if (!s) continue;
                 if (s.sharedMaterial == material) return s;
             }
 


### PR DESCRIPTION
## Description

This fixes TMP submesh selection when TextMeshPro uses multiple dynamic atlas materials.

TmpProxy previously selected TMP_SubMeshUI by shared material only. In long-running sessions or after TMP dynamic atlas changes, stale UIEffectReplica submeshes can remain with matching materials, which may cause UIEffect to modify or render the wrong submesh.

This change selects the TMP_SubMeshUI whose mesh matches the current TMP_MeshInfo.mesh first, then falls back to the existing material-based lookup.

Fixes: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor Windows
- Unity version: 6000.3.14f1
- Build options: Built-in Render Pipeline, TextMeshPro dynamic multi-atlas, UIEffect enabled

## Checklist

- [x] This pull request is for merging into the `main` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Tests

- `git diff --check -- Packages/src/Runtime/Utilities/TmpProxy.cs`
- Verified in an integration project using TextMeshPro dynamic multi-atlas and UIEffect enabled.