### PR TITLE
fix: refresh material when changing shadow mode

### DIFF
--- a/Packages/src/Runtime/UIEffect.cs
+++ b/Packages/src/Runtime/UIEffect.cs
@@ -843,7 +843,7 @@ namespace Coffee.UIEffects
                 if (m_ShadowMode == value) return;
                 context.m_ShadowMode = m_ShadowMode = value;
                 SetVerticesDirty();
-                SetVerticesDirty();
+                SetMaterialDirty();
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

- Fix the material not being refreshed when `shadowMode` changes at runtime between `None` and an enabled mode such as `Outline`.
- Replace the duplicated `SetVerticesDirty()` call in the `shadowMode` setter with `SetMaterialDirty()`.
- This reevaluates the CanvasRenderer material and propagates the material refresh to TMP submesh replicas.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor (Windows), Standalone (Windows)
- Unity version: 6000.3.20f1
- Build options: Built-in Render Pipeline, StandaloneWindows64
- Validation:
  - All 6 EditMode tests passed, including local regression coverage for dirty callbacks, CanvasRenderer material, and TMP main/submesh material transitions.
  - StandaloneWindows64 player build succeeded.

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
