### PR TITLE
fix: ignore shader registry order changes

### DIFF
--- a/Packages/src/Runtime/Internal/Utilities/ShaderVariantRegistry.cs
+++ b/Packages/src/Runtime/Internal/Utilities/ShaderVariantRegistry.cs
@@ -288,8 +288,10 @@ namespace Coffee.UIEffectInternal
                 .Distinct()
                 .ToList();
 
-            // If the registered shaders are already in sync with the SVC, no need to update.
-            if (m_RegisteredShaders.SequenceEqual(shadersInSVC))
+            // ShaderVariantCollection entry order is not stable between editor sessions.
+            // The registry is a lookup set, so an order-only difference is already in sync.
+            if (m_RegisteredShaders.Count == shadersInSVC.Count &&
+                new HashSet<Shader>(m_RegisteredShaders).SetEquals(shadersInSVC))
             {
                 return;
             }


### PR DESCRIPTION
## Description

- Treat the registered shader collection as a set when checking synchronization.
- Ignore order-only differences caused by unstable `ShaderVariantCollection.m_Shaders` ordering.
- Preserve the existing rebuild and dirty behavior for real membership changes, nulls, or duplicates.

Fixes #407

Twin pull request for the shared implementation: https://github.com/mob-sakai/SoftMaskForUGUI/pull/274

The order-only path now keeps the existing registered order. `InitializeShaderLookup` is name-keyed rather than index-correlated with the SVC. Duplicate shader names would remain last-wins as before; the current package registries use distinct shader names and the previous order was already unstable.

Residual scope: this removes the self-inflicted order-only dirty trigger. An unrelated legitimate edit can still cause Unity to serialize its native SVC order; this pull request does not canonicalize Unity internals.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Update documentations
- [ ] Others (refactoring, style changes, etc.)

## Test environment

- Platform: Editor (Windows)
- Unity version: 6000.5.5f1
- Tested package: `5.11.5` plus this patch
- PR base: `develop` / `5.11.6`; the changed source region is identical

Verified that:

- The package compiles without new errors.
- A forced SVC/registry order mismatch leaves the settings owner clean.
- Saving after initialization leaves the mismatched asset byte-identical.
- Restoring the permutation returns the asset byte-identically to its original state.
- A real shader addition still rebuilds the registered shader list.

## Checklist

- [x] This pull request is for merging into the `develop` branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings